### PR TITLE
chore: fix validation error for resource_allocation

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,7 @@ variable "resource_allocation" {
     storage = 128
   }
   validation {
-    condition     = var.resource_allocation.cores > var.resource_allocation.vcpus
+    condition     = var.resource_allocation.cores >= var.resource_allocation.vcpus
     error_message = "CPU cores cannot be lesser than VCPUs."
   }
   validation {


### PR DESCRIPTION
There's a mistake in the validation for 
```
var.resource_allocation.cores > var.resource_allocation.vcpus
```

This should in fact be 
```
var.resource_allocation.cores >= var.resource_allocation.vcpus
```

as the config for cores and vcpus can be equals to each other but not vcpus larger than cores.